### PR TITLE
update extended template name

### DIFF
--- a/plugins/templates/rest_api_plugin/index.html
+++ b/plugins/templates/rest_api_plugin/index.html
@@ -1,4 +1,4 @@
-{% extends "airflow/master.html" %}
+{% extends "airflow/main.html" %}
 
 {% block title %}Airflow - REST API Plugin{% endblock %}
 


### PR DESCRIPTION
currently in Airflow:2.1.2 the `master.html` has been renamed to `main.html`